### PR TITLE
workaround for #3

### DIFF
--- a/templates/init.j2
+++ b/templates/init.j2
@@ -51,7 +51,7 @@ JAR_ARGS=${JAR_ARGS:-""}
 JAVA_OPTS=${JAVA_OPTS:-""}
 
 
-SYSTEM_JAVA=$(/usr/sbin/update-alternatives --query java|grep Value|cut -f 2 -d":")
+SYSTEM_JAVA=$(update-alternatives --query java|grep Value|cut -f 2 -d":")
 if [ -z "$JAVA_HOME" -a ! -z "${SYSTEM_JAVA}" ]; then
     JAVA_HOME=$(dirname "${SYSTEM_JAVA}")
     JAVA_HOME=${JAVA_HOME%/bin}


### PR DESCRIPTION
Not specifying a full pathname for update-alternatives works on ubuntu-14.04. I did not test the rest of distro's.