### PR TITLE
Avoid adding invalid role when standalone

### DIFF
--- a/templates/init.j2
+++ b/templates/init.j2
@@ -83,7 +83,7 @@ start)
     fi
     install -o ${SE_USER} -g ${SE_GROUP} -d ${JVM_TMP}
 
-    if [ ! -z "${ROLE}" ]; then
+    if [ ! -z "${ROLE}" ] && [ "${ROLE}" != "standalone" ]; then
         JAR_ARGS="-role ${ROLE}"
     fi
     if [ ! -z "${HUB}" ]; then


### PR DESCRIPTION
Adding `-role standalone` creates the following exception:
```
Exception in thread "main" org.openqa.grid.common.exception.GridConfigurationException: The role specified :standalone doesn't match a recognized role for grid.
	at org.openqa.grid.common.GridRole.find(GridRole.java:50)
	at org.openqa.grid.selenium.GridLauncher.main(GridLauncher.java:92)
```

P.S. it looks like only `hub` and `node` are only allowed (http://www.seleniumhq.org/docs/07_selenium_grid.jsp#starting-selenium-grid)